### PR TITLE
authenticated-extended-agent-card

### DIFF
--- a/examples/server-hello-world/main.go
+++ b/examples/server-hello-world/main.go
@@ -65,6 +65,29 @@ func main() {
 		c.JSON(http.StatusOK, a2aServer.GetSelfAgentCard())
 	})
 
+	router.GET("/a2a/agent/authenticatedExtendedCard", func(c *gin.Context) {
+		// This is a placeholder for actual authentication logic.
+		// In a real application, you would validate the API key against a database or a secure store.
+		apiKey := c.GetHeader("X-API-Key")
+		if apiKey == "" {
+			c.JSON(http.StatusUnauthorized, gin.H{"error": "API key required"})
+			return
+		}
+
+		// Example of simple key check
+		if apiKey != "your-secure-api-key" {
+			c.JSON(http.StatusForbidden, gin.H{"error": "Invalid API key"})
+			return
+		}
+
+		extendedCard, err := a2aServer.GetAuthenticatedExtendedCard(c.Request.Context())
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to get extended agent card"})
+			return
+		}
+		c.JSON(http.StatusOK, extendedCard)
+	})
+
 	router.POST("/a2a/server", func(c *gin.Context) {
 		// 检查是否为 SSE 流式请求
 		if c.GetHeader("Accept") == "text/event-stream" {

--- a/internal/model/agent_card.go
+++ b/internal/model/agent_card.go
@@ -24,7 +24,7 @@ type AgentCard struct {
 	DocumentationURL string `json:"documentationUrl,omitempty"`
 
 	// Capabilities are the capabilities supported by the agent
-	Capabilities *AgentCapabilities `json:"capabilities"`
+	Capabilities *AgentCapabilities `json:"capabilities,omitempty"`
 
 	// Authentication are authentication details required to interact with the agent
 	Authentication *AgentAuthentication `json:"authentication,omitempty"`
@@ -42,26 +42,30 @@ type AgentCard struct {
 	DefaultOutputModes []string `json:"defaultOutputModes,omitempty"`
 
 	// Skills are specific skills offered by the agent
-	Skills []*AgentSkill `json:"skills"`
+	Skills []*AgentSkill `json:"skills,omitempty"`
+
+	// SupportsAuthenticatedExtendedCard is whether the agent supports authenticated extended card
+	SupportsAuthenticatedExtendedCard bool `json:"supportsAuthenticatedExtendedCard,omitempty"`
 }
 
 // NewAgentCard creates a new agent card
-func NewAgentCard(id string, name string, description string, url string, provider *AgentProvider, version string, documentationURL string, capabilities *AgentCapabilities, authentication *AgentAuthentication, securitySchemes map[string]*SecurityScheme, security []map[string][]string, defaultInputModes []string, defaultOutputModes []string, skills []*AgentSkill) *AgentCard {
+func NewAgentCard(id string, name string, description string, url string, provider *AgentProvider, version string, documentationURL string, capabilities *AgentCapabilities, authentication *AgentAuthentication, securitySchemes map[string]*SecurityScheme, security []map[string][]string, defaultInputModes []string, defaultOutputModes []string, skills []*AgentSkill, supportsAuthenticatedExtendedCard bool) *AgentCard {
 	return &AgentCard{
-		ID:                 id,
-		Name:               name,
-		Description:        description,
-		URL:                url,
-		Provider:           provider,
-		Version:            version,
-		DocumentationURL:   documentationURL,
-		Capabilities:       capabilities,
-		Authentication:     authentication,
-		SecuritySchemes:    securitySchemes,
-		Security:           security,
-		DefaultInputModes:  defaultInputModes,
-		DefaultOutputModes: defaultOutputModes,
-		Skills:             skills,
+		ID:                                id,
+		Name:                              name,
+		Description:                       description,
+		URL:                               url,
+		Provider:                          provider,
+		Version:                           version,
+		DocumentationURL:                  documentationURL,
+		Capabilities:                      capabilities,
+		Authentication:                    authentication,
+		SecuritySchemes:                   securitySchemes,
+		Security:                          security,
+		DefaultInputModes:                 defaultInputModes,
+		DefaultOutputModes:                defaultOutputModes,
+		Skills:                            skills,
+		SupportsAuthenticatedExtendedCard: supportsAuthenticatedExtendedCard,
 	}
 }
 
@@ -203,4 +207,14 @@ func (c *AgentCard) GetSkills() []*AgentSkill {
 // SetSkills sets the agent skills
 func (c *AgentCard) SetSkills(skills []*AgentSkill) {
 	c.Skills = skills
+}
+
+// GetSupportsAuthenticatedExtendedCard returns whether the agent supports authenticated extended card
+func (c *AgentCard) GetSupportsAuthenticatedExtendedCard() bool {
+	return c.SupportsAuthenticatedExtendedCard
+}
+
+// SetSupportsAuthenticatedExtendedCard sets whether the agent supports authenticated extended card
+func (c *AgentCard) SetSupportsAuthenticatedExtendedCard(supports bool) {
+	c.SupportsAuthenticatedExtendedCard = supports
 }

--- a/internal/service/server/impl/default_a2a_server.go
+++ b/internal/service/server/impl/default_a2a_server.go
@@ -388,3 +388,17 @@ func (s *DefaultA2AServer) SubscribeToTaskUpdates(ctx context.Context, taskID st
 func (s *DefaultA2AServer) GetSelfAgentCard() *model.AgentCard {
 	return s.agentCard
 }
+
+// GetAuthenticatedExtendedCard retrieves the authenticated extended AgentCard for the server.
+// By default, this returns the same card as getSelfAgentCard().
+// Subclasses can override this method to provide more detailed information
+// for authenticated clients.
+func (s *DefaultA2AServer) GetAuthenticatedExtendedCard(ctx context.Context) (*model.AgentCard, error) {
+	// TODO: Implement logic to return a more detailed AgentCard for authenticated clients.
+	// This may involve:
+	// 1. Checking the authenticated principal (if applicable through security context).
+	// 2. Loading a different AgentCard configuration or modifying the existing one.
+	// 3. Adding skills or details that are not available in the public AgentCard.
+	// For now, it returns the same card as getSelfAgentCard().
+	return s.agentCard, nil
+}

--- a/pkg/service/client/a2a_client.go
+++ b/pkg/service/client/a2a_client.go
@@ -39,6 +39,10 @@ type A2aClient interface {
 	// Returns a channel that emits task update events.
 	ResubscribeTask(ctx context.Context, params *model2.TaskQueryParams) (<-chan model2.SendStreamingMessageResponse, error)
 
+	// RetrieveAuthenticatedExtendedAgentCard retrieves the authenticated extended AgentCard.
+	// This requires providing authentication details (e.g., an API key).
+	RetrieveAuthenticatedExtendedAgentCard(ctx context.Context, authToken string) (*model2.AgentCard, error)
+
 	// Supports checks if the server likely supports optional methods based on agent card.
 	// This is a client-side heuristic and might not be perfectly accurate.
 	Supports(capability string) bool

--- a/pkg/service/server/a2a_server.go
+++ b/pkg/service/server/a2a_server.go
@@ -31,4 +31,8 @@ type A2AServer interface {
 
 	// GetSelfAgentCard retrieves the AgentCard for this server
 	GetSelfAgentCard() *model.AgentCard
+
+	// GetAuthenticatedExtendedCard retrieves the authenticated extended AgentCard for this server.
+	// This method should return a more detailed version of the Agent Card if the client is authenticated.
+	GetAuthenticatedExtendedCard(ctx context.Context) (*model.AgentCard, error)
 }


### PR DESCRIPTION
This commit introduces the ability for an agent to provide an extended, more detailed AgentCard to authenticated clients.

- Adds a `supportsAuthenticatedExtendedCard` flag to the `AgentCard` model.
- Implements a new server endpoint `/a2a/agent/authenticatedExtendedCard` that requires an API key for access.
- Extends the A2A server and client interfaces with methods to retrieve the authenticated extended card.
- Provides a sample implementation in the hello-world example.